### PR TITLE
New Toy: Scriptable Object Creator

### DIFF
--- a/Scripts/ScriptableObjectCreator.cs
+++ b/Scripts/ScriptableObjectCreator.cs
@@ -10,9 +10,9 @@ namespace Hibzz
 {
     public static class ScriptableObjectCreator
     {
-        const string MENU_KEY = "Assets/Create Scriptable Object Instance";
+        const string MENU_KEY = "Assets/Create/Scriptable Object Instance";
 
-        [MenuItem(MENU_KEY)]
+        [MenuItem(MENU_KEY, priority = 120)]
         private static void CreateScriptableObject()
         {
             // not going to do any validation at the moment because of the

--- a/Scripts/ScriptableObjectCreator.cs
+++ b/Scripts/ScriptableObjectCreator.cs
@@ -1,0 +1,52 @@
+#if UNITY_EDITOR
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+namespace Hibzz
+{
+    public static class ScriptableObjectCreator
+    {
+        const string MENU_KEY = "Assets/Create Scriptable Object Instance";
+
+        [MenuItem(MENU_KEY)]
+        private static void CreateScriptableObject()
+        {
+            // not going to do any validation at the moment because of the
+            // validation function below... This button will be inactive if the
+            // validation fails, so assume that every operation performed here
+            // is valid
+            var monoscript = Selection.activeObject as MonoScript;
+            var class_type = monoscript.GetClass();
+
+            // figure out the new file name of this asset
+            var directory_name = Path.GetDirectoryName(AssetDatabase.GetAssetPath(monoscript));
+            var filepath = $"{directory_name}/{class_type.Name}.asset";
+            var unique_path = AssetDatabase.GenerateUniqueAssetPath(filepath);
+
+            // create the scriptable object and store it in the asset database
+            var instance = ScriptableObject.CreateInstance(class_type);
+            AssetDatabase.CreateAsset(instance, unique_path);
+        }
+
+        [MenuItem(MENU_KEY, validate = true)]
+        private static bool CreateScriptableObjectValidate()
+        {
+            // selected object must be a monobehavior script
+            var monoscript = Selection.activeObject as MonoScript;
+            if(monoscript is null) { return false; }
+
+            // selected monobehavior script must be derived from ScriptableObject
+            var class_type = monoscript.GetClass();
+            if(!class_type.IsSubclassOf(typeof(ScriptableObject))) { return false; }
+
+            // all checks passed, the selection is valid
+            return true;
+        }
+    }
+}
+
+#endif

--- a/Scripts/ScriptableObjectCreator.cs.meta
+++ b/Scripts/ScriptableObjectCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1369f6129fbbfa745b4b12aec5b9a43c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request adds a new toy called the Scriptable Object Creator, which adds a new button to the *assets/create* menu called *"Create Scriptable Object Instance"*. When the user selects a script file and presses this option, it would create a new scriptable object.

This button is disabled if the selected file isn't a script file or if the script doesn't inherit `ScriptableObject`

Image Preview:
![ss](https://github.com/hibzzgames/Hibzz.EditorToys/assets/37605842/9b352588-8727-4cf2-8c85-fd93e289a809)

