### PR TITLE
Bug Fix: Save Release Incrementor Preference

### DIFF
--- a/Scripts/ReleaseIncrementor.cs
+++ b/Scripts/ReleaseIncrementor.cs
@@ -17,10 +17,17 @@ namespace Hibzz
 
             public int callbackOrder => 0;
 
-            public void OnPreprocessBuild(BuildReport report)
+            [InitializeOnLoadMethod]
+            public static void Initialize()
+            {
+                // ISSUE: doesn't work when it's first called when the editor is launched
+                Menu.SetChecked(MENU_KEY, EditorPrefs.GetBool(MENU_KEY, false));
+            }
+
+            public void OnPreprocessBuild(BuildReport report) 
             {
                 // only execute the tool's code if it was enabled
-                if (!Menu.GetChecked(MENU_KEY)) { return; }
+                if (!EditorPrefs.GetBool(MENU_KEY, false)) { return; }
 
                 // Ask the user if they want to increment the release version
                 // A response of "1" means the user decided to not increment the release version
@@ -50,7 +57,8 @@ namespace Hibzz
             [MenuItem(MENU_KEY)]
             static void ToggleReleaseIncrementor()
             {
-                Menu.SetChecked(MENU_KEY, !Menu.GetChecked(MENU_KEY));
+                Menu.SetChecked(MENU_KEY, !EditorPrefs.GetBool(MENU_KEY, false));
+                EditorPrefs.SetBool(MENU_KEY, Menu.GetChecked(MENU_KEY));
             }
         }
     }


### PR DESCRIPTION
This pull request fixes a bug where the release incrementor preference doesn't get saved when the user exits the editor and re-opens it later. Switching to store content in `EditorPrefs` as well as `Menu` based on the `MENU_KEY` variable solves the issue.

However, there's a small issue that persists. Although the tool might be active, the checkmark doesn't appear on the menu button until another domain reload. For some reason, I mean I kinda get it, the first `[InitializeOnLoad]` call is made even before the editor fully loads, so any `Menu.SetChecked(key, bool)` call doesn't work, even if the right value is read and passed. That kinda sucks.

This is a problem I would like to tackle at some point later, but I'm kinda tired of Unity's mess. Closes #3 