### PR TITLE
Added Disable Flags

### DIFF
--- a/Scripts/DefineRegistrant.cs
+++ b/Scripts/DefineRegistrant.cs
@@ -1,0 +1,30 @@
+#if ENABLE_DEFINE_MANAGER
+
+using Hibzz.DefineManager;
+
+namespace Hibzz.EditorToys
+{
+    internal static class DefineRegistrant
+    {
+        const string Category = "Hibzz.EditorToys";
+
+        [RegisterDefine]
+        static DefineRegistrationData RegisterPrintToScreen()
+        {
+            DefineRegistrationData data = new DefineRegistrationData();
+
+            data.Define = "DISABLE_PRINT_TO_SCREEN";
+            data.DisplayName = "Disable Print To Screen";
+            data.Category = Category;
+            data.EnableByDefault = false;
+            data.Description = "Print to Screen is an editor toy that let's " +
+                "users print debug statements to the screen with the given " +
+                "color for the requested duration.\n\n" +
+                "Installing this define will disable this tool.";
+
+            return data;
+        }
+    }
+}
+
+#endif

--- a/Scripts/DefineRegistrant.cs
+++ b/Scripts/DefineRegistrant.cs
@@ -24,6 +24,24 @@ namespace Hibzz.EditorToys
 
             return data;
         }
+
+        [RegisterDefine]
+        static DefineRegistrationData RegisterReleaseIncrementor()
+        {
+            DefineRegistrationData data = new DefineRegistrationData();
+
+            data.Define = "DISABLE_RELEASE_INCREMENTOR";
+            data.DisplayName = "Disable Release Incrementor";
+            data.Category = Category;
+            data.EnableByDefault = false;
+            data.Description = "The Release Incrementor, when enabled, prompts " +
+                "the user to increase the version number of the application " +
+                "(the patch or the minor number) when the user creates a new " +
+                "build.\n\n" +
+                "Installing this define disables the Release Incrementor.";
+
+            return data;
+        }
     }
 }
 

--- a/Scripts/DefineRegistrant.cs
+++ b/Scripts/DefineRegistrant.cs
@@ -42,6 +42,24 @@ namespace Hibzz.EditorToys
 
             return data;
         }
+
+        [RegisterDefine]
+        static DefineRegistrationData RegisterScriptableObjectCreator()
+        {
+            DefineRegistrationData data = new DefineRegistrationData();
+
+            data.Define = "DISABLE_SCRIPTABLE_OBJECT_CREATOR";
+            data.DisplayName = "Disable Scriptable Object Creator";
+            data.Category = Category;
+            data.EnableByDefault = false;
+            data.Description = "The Scriptable Object Creator is a utility that " +
+                "lets users right click on a script file that contains a class " +
+                "that inherits ScriptableObject and create new scriptable " +
+                "object instance without any other additional menu items.\n\n" +
+                "Installing this define disables the Scriptable Object Creator";
+
+            return data;
+        }
     }
 }
 

--- a/Scripts/DefineRegistrant.cs.meta
+++ b/Scripts/DefineRegistrant.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 078e90a4960c48646867030e1562e68b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/EditorToys.cs
+++ b/Scripts/EditorToys.cs
@@ -30,7 +30,10 @@ namespace Hibzz.EditorToys
             // create the instance of the object at runtime and add hooks to it
             // accessing the instance property is a cheap way to create the object
             var hooks = EditorToysHooks.Instance;
+
+            #if !DISABLE_PRINT_TO_SCREEN
             EditorToysHooks.OnGuiHandler += PrintQueue.OnGui;
+            #endif
 
             // remove all hooks when the hook object is destroyed
             EditorToysHooks.HookDestroyHandler += RemoveSelfFromEditorHook;
@@ -46,12 +49,17 @@ namespace Hibzz.EditorToys
             lastTimeSinceStartup = EditorApplication.timeSinceStartup;
 
             // call update for other editor tools
+            #if !DISABLE_PRINT_TO_SCREEN
             PrintQueue.Update();
+            #endif
         }
 
         private static void RemoveSelfFromEditorHook()
         {
+            #if !DISABLE_PRINT_TO_SCREEN
             EditorToysHooks.OnGuiHandler -= PrintQueue.OnGui;
+            #endif
+
             EditorToysHooks.HookDestroyHandler -= RemoveSelfFromEditorHook;
         }
     }

--- a/Scripts/PrintToScreen.cs
+++ b/Scripts/PrintToScreen.cs
@@ -1,4 +1,5 @@
 // This file contains the code for the PrintToScreen Functions
+#if !DISABLE_PRINT_TO_SCREEN
 
 using System.Collections.Generic;
 using UnityEngine;
@@ -195,3 +196,5 @@ namespace Hibzz.EditorToys
         }
     }
 }
+
+#endif

--- a/Scripts/ReleaseIncrementor.cs
+++ b/Scripts/ReleaseIncrementor.cs
@@ -1,6 +1,6 @@
 // This file contains the code for the ReleaseIncrementor functions
 
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !DISABLE_RELEASE_INCREMENTOR
 
 using UnityEditor;
 using UnityEditor.Build;

--- a/Scripts/ScriptableObjectCreator.cs
+++ b/Scripts/ScriptableObjectCreator.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !DISABLE_SCRIPTABLE_OBJECT_CREATOR
 
 using UnityEngine;
 using UnityEditor;

--- a/com.hibzz.editortoys.asmdef
+++ b/com.hibzz.editortoys.asmdef
@@ -2,7 +2,8 @@
     "name": "com.hibzz.editortoys",
     "rootNamespace": "Hibzz.EditorToys",
     "references": [
-        "GUID:b2fef9eae29790340a713d8578864b00"
+        "GUID:b2fef9eae29790340a713d8578864b00",
+        "GUID:b844f493a2cd07b4cbf81917a23ac063"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
With many tools that are part of this package, users may not be interested in all of the toys. So, this pull request adds options to disable specific tools with scriptable defines. Adding the following scriptable defines disables the following features.

- `DISABLE_PRINT_TO_SCREEN` - Disables Print To Screen
- `DISABLE_RELEASE_INCREMENTOR` - Disables Release Incrementor
- `DISABLE_SCRIPTABLE_OBJECT_CREATOR` - Disable Scriptable Scriptable Object Creator

Additionally, this tool has integration with [Hibzz.DefineManager](https://github.com/hibzzgames/Hibzz.DefineManager) which adds a neat visual way to interact with the scriptable defines to enable/disable features.
