### PR TITLE
Documentation: Update Readme about the available tools with Editor Toys 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ The Release Incrementor prompts the users to increment the version number of the
 <br>
 
 ### Scriptable Object Creator
+<img src="https://github.com/hibzzgames/Hibzz.EditorToys/assets/37605842/b0dbbb77-4dc2-4a51-aece-f85e2133a84d" width="50%">
 
-*// todo: add a screenshot*
 
 The Scriptable Object Creator allows users to create a new instance of a scriptable object directly by opening the context menu on a script file that inherits from `ScriptableObject`. This lets users avoid having to create a unique menu item for each scriptable object type they create reducing the clutter in the Unity Editor and improving the workflow. 
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,60 @@ Alternatively, you can download the latest release from the [releases page](http
 
 <br>
 
-## Usage
+## Tools
 The following tools are currently available:
 - [Print To Screen](https://github.com/hibzzgames/Hibzz.EditorToys/edit/master/README.md#print-to-screen)
+- [Release Incrementor](https://github.com/hibzzgames/Hibzz.EditorToys/edit/master/README.md#release-incrementor)
+- [Scriptable Object Creator](https://github.com/hibzzgames/Hibzz.EditorToys/edit/master/README.md#scriptable-object-creator)
 
 <br>
 
 ### Print To Screen
-*// TODO*
+
+*// todo: add a screenshot*
+
+`PrintToScreen` is a simple tool that allows users to print a message to the screen for a specified duration. This is very useful for real-time debugging and testing. The tool can be further customized by specifying the color of the text.
+
+
+```csharp
+using Hibzz.EditorToys;
+
+// print message to the screen
+EditorToys.PrintToScreen("Hello World!"); // prints "Hello World!" to the screen for 1 frame
+EditorToys.PrintToScreen("Hello World!", 5f); // prints "Hello World!" to the screen for 5 seconds
+EditorToys.PrintToScreen("Hello World!", Color.red); // prints "Hello World!" to the screen for 1 frame in red
+EditorToys.PrintToScreen("Hello World!", 5f, Color.red); // prints "Hello World!" to the screen for 5 seconds in red
+```
 
 <br>
+
+### Release Incrementor
+
+*// todo: add a screenshot*
+
+The Release Incrementor prompts the users to increment the version number of the project when creating a new build. With a press of a button, users will be able to increment the patch or minor version number of the project. This tool can be enabled from the `Hibzz > Editor Toys > Release Incrementor` menu.
+
+
+<br>
+
+### Scriptable Object Creator
+
+*// todo: add a screenshot*
+
+The Scriptable Object Creator allows users to create a new instance of a scriptable object directly by opening the context menu on a script file that inherits from `ScriptableObject`. This lets users avoid having to create a unique menu item for each scriptable object type they create reducing the clutter in the Unity Editor and improving the workflow. 
+
+<br>
+
+## Disabling Tools
+Since this package contains a wide variety of tools, it is completely understandable if you don't want to use all of them. The Editor Toys package adds support for disabling tools using scripting define symbols. 
+
+This package has tight integration with the [Hibzz.DefineManager](https://github.com/hibzzgames/Hibzz.DefineManager) package which allows users to visually interact with the defines from the Unity Editor. The users can read what each of the scripting define symbols do in a neat interface and enable/disable the tools with a click of a button.
+
+The following symbols can be used to disable specific tools:
+
+- `DISABLE_PRINT_TO_SCREEN`
+- `DISABLE_RELEASE_INCREMENTOR`
+- `DISABLE_SCRIPTABLE_OBJECT_CREATOR`
 
 ## Have a question or want to contribute?
 If you have any questions or want to contribute, feel free to join the [Discord server](https://discord.gg/YXdJ8cZngB) or [Twitter](https://twitter.com/hibzzgames). I'm always looking for feedback and ways to improve this tool. Thanks!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The following tools are currently available:
 
 ### Print To Screen
 
-*// todo: add a screenshot*
+![printtoscreen](https://github.com/hibzzgames/Hibzz.EditorToys/assets/37605842/0e6ff149-803d-48c5-901f-1cb11b9c02d2)
+
 
 `PrintToScreen` is a simple tool that allows users to print a message to the screen for a specified duration. This is very useful for real-time debugging and testing. The tool can be further customized by specifying the color of the text.
 
@@ -55,7 +56,7 @@ The Release Incrementor prompts the users to increment the version number of the
 <br>
 
 ### Scriptable Object Creator
-<img src="https://github.com/hibzzgames/Hibzz.EditorToys/assets/37605842/b0dbbb77-4dc2-4a51-aece-f85e2133a84d" width="50%">
+<img src="https://github.com/hibzzgames/Hibzz.EditorToys/assets/37605842/b0dbbb77-4dc2-4a51-aece-f85e2133a84d" width="70%">
 
 
 The Scriptable Object Creator allows users to create a new instance of a scriptable object directly by opening the context menu on a script file that inherits from `ScriptableObject`. This lets users avoid having to create a unique menu item for each scriptable object type they create reducing the clutter in the Unity Editor and improving the workflow. 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ EditorToys.PrintToScreen("Hello World!", 5f, Color.red); // prints "Hello World!
 
 ### Release Incrementor
 
-*// todo: add a screenshot*
+![release-incrementor](https://github.com/hibzzgames/Hibzz.EditorToys/assets/37605842/6ada618e-7f0a-418b-938d-9023a972fc36)
 
 The Release Incrementor prompts the users to increment the version number of the project when creating a new build. With a press of a button, users will be able to increment the patch or minor version number of the project. This tool can be enabled from the `Hibzz > Editor Toys > Release Incrementor` menu.
 


### PR DESCRIPTION
This pull request adds documentation on how to use the tools that will be part of Editor Toys 1.0 such as Print To Screen, Release Incrementor, and Scripable Object Creator.